### PR TITLE
fix #3 client-does-not-return-flags

### DIFF
--- a/bullet-train-core.js
+++ b/bullet-train-core.js
@@ -62,7 +62,7 @@ const BulletTrain = class {
         } else {
             return this.getJSON(api + "flags/")
                 .then(res => {
-                    handleResponse(res)
+                    handleResponse({flags: res})
                 }).catch(({ message }) => {
                     onError && onError({ message })
                 });


### PR DESCRIPTION
This fix #3 by passing the proper object structure to handleResponse when getFlags() is called without an identity.