### PR TITLE
Use AsyncStorage from @callstack for React Native

### DIFF
--- a/index.react-native.js
+++ b/index.react-native.js
@@ -1,3 +1,3 @@
-import {AsyncStorage} from 'react-native';
+import AsyncStorage from "@callstack/async-storage";
 const bt = require('./bullet-train-core');
 module.exports = bt({AsyncStorage});


### PR DESCRIPTION
The bullet-train-react-native client is using AsyncStorage from React Native core, which has been deprecated starting from React Native version 0.59 as part of the Lean Core initiative. The way to move forward is to use the @react-native-community/async-storage library instead.

This is causing issues/conflicts for projects (like mine) that is using the new library.

We can fix that issue by using the AsyncStorage from @callstack which already depends on the correct library.